### PR TITLE
Bug Fix: Timescale and Win Condition

### DIFF
--- a/Assets/Scripts/LoadLevel.cs
+++ b/Assets/Scripts/LoadLevel.cs
@@ -8,17 +8,20 @@ public class LoadLevel : MonoBehaviour
     public void LoadNextLevel(int levelNum)
     {
         GlobalVariables.Level = levelNum;
+        Time.timeScale = 1f;
     }
 
     public void LoadScene(string sceneName)
     {
         // Load the scene with the specified name
+        Time.timeScale = 1f;
         SceneManager.LoadScene(sceneName);
     }
 
     public void LoadScene(int idx)
     {
         SceneManager.LoadScene(idx);
+        Time.timeScale = 1f;
     }
 
     public void SendResult(bool result)
@@ -50,6 +53,7 @@ public class LoadLevel : MonoBehaviour
             levelInfo.DeadTimesUp++;
             levelInfo.CoinCollected = 0;
         }
+        Time.timeScale = 1f;
         SceneManager.LoadScene(currentIdx);
     }
 }

--- a/Assets/Scripts/PlayerControls.cs
+++ b/Assets/Scripts/PlayerControls.cs
@@ -28,7 +28,7 @@ public class PlayerControls : MonoBehaviour
 	public GameObject[] walls;
 	private int availablePowerUps = 0;
 	public TextMeshProUGUI powerUpText;
-
+	private Rigidbody playerobjectrb;
 
 	void Start()
     {
@@ -48,6 +48,7 @@ public class PlayerControls : MonoBehaviour
 		}
 		_levelInfo = GlobalVariables.LevelInfo;
 		lastBlockPosition = transform.position;
+		playerobjectrb = GameObject.FindWithTag("Player").GetComponent<Rigidbody>();
 	}
 
     void Update()
@@ -97,6 +98,9 @@ public class PlayerControls : MonoBehaviour
 			Debug.Log("Win tIle");
 			_levelInfo.CalculateInterval(DateTime.Now);
 			GameWinPanelDisplay();
+			playerobjectrb.velocity = Vector3.zero;
+            playerobjectrb.angularVelocity = Vector3.zero;
+            Time.timeScale = 0f;
 			//WinText.text = "You Win!!";
 		}
 

--- a/Assets/Scripts/PlayerControls.cs
+++ b/Assets/Scripts/PlayerControls.cs
@@ -28,7 +28,7 @@ public class PlayerControls : MonoBehaviour
 	public GameObject[] walls;
 	private int availablePowerUps = 0;
 	public TextMeshProUGUI powerUpText;
-	private Rigidbody playerobjectrb;
+
 
 	void Start()
     {
@@ -48,7 +48,7 @@ public class PlayerControls : MonoBehaviour
 		}
 		_levelInfo = GlobalVariables.LevelInfo;
 		lastBlockPosition = transform.position;
-		playerobjectrb = GameObject.FindWithTag("Player").GetComponent<Rigidbody>();
+
 	}
 
     void Update()
@@ -98,8 +98,6 @@ public class PlayerControls : MonoBehaviour
 			Debug.Log("Win tIle");
 			_levelInfo.CalculateInterval(DateTime.Now);
 			GameWinPanelDisplay();
-			playerobjectrb.velocity = Vector3.zero;
-            playerobjectrb.angularVelocity = Vector3.zero;
             Time.timeScale = 0f;
 			//WinText.text = "You Win!!";
 		}

--- a/Assets/Scripts/TimerController.cs
+++ b/Assets/Scripts/TimerController.cs
@@ -18,6 +18,8 @@ public class TimerController : MonoBehaviour
     public TextMeshProUGUI timerText;  // Reference to your TextMeshPro text object
     public GameObject gameOverPanel;
     // Start is called before the first frame update
+
+
     void Start()
     {
         _timer = countdownTime;


### PR DESCRIPTION
Pauses player movement after winning, sets timescale to 0 to avoid game over screen and ensures correct timescale when loading levels